### PR TITLE
Updated Dockerfile to remove proxy option from curl command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL name="rhosp13/openstack-cinder-volume-hpe" \
 USER root
 
 # install python module python-3parclient(dependent module for HPE 3PAR Cinder driver)
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" --proxy ${http_proxy} && https_proxy=${https_proxy} python get-pip.py && https_proxy=${https_proxy} pip install python-3parclient==4.2.8 && rm get-pip.py
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && python get-pip.py && pip install python-3parclient==4.2.8 && rm get-pip.py
 
 # Add required license as text file in Liceses directory (GPL, MIT, APACHE, Partner End User Agreement, etc)
 COPY licenses /licenses

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL name="rhosp13/openstack-cinder-volume-hpe" \
 USER root
 
 # install python module python-3parclient(dependent module for HPE 3PAR Cinder driver)
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && python get-pip.py && pip install python-3parclient==4.2.8 && rm get-pip.py
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && python get-pip.py && pip install python-3parclient==4.2.9 && rm get-pip.py
 
 # Add required license as text file in Liceses directory (GPL, MIT, APACHE, Partner End User Agreement, etc)
 COPY licenses /licenses


### PR DESCRIPTION
Removed proxy from curl command as https://connect.redhat.com/project/984951/build-service/build/6/view is failing with below error  when curl is used with proxy option in Dockerfile:

curl: option --proxy: requires parameter
curl: try 'curl --help' or 'curl --manual' for more information
[0mRemoving intermediate container d2ad0ea4dbd4
error: build error: The command '/bin/sh -c curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" --proxy ${http_proxy} && https_proxy=${https_proxy} python get-pip.py && https_proxy=${https_proxy} pip install python-3parclient==4.2.8 && rm get-pip.py' returned a non-zero code: 2