### PR TITLE
Sample 3par backend yaml files

### DIFF
--- a/custom_hpe_images_fc.yaml
+++ b/custom_hpe_images_fc.yaml
@@ -1,0 +1,88 @@
+parameter_defaults:
+  DockerCinderVolumeImage: 10.50.9.100:8787/rhosp13/openstack-cinder-volume-hpe:latest
+  CinderEnableIscsiBackend: false
+  Debug: true
+  ControllerExtraConfig:
+    pacemaker::resource::bundle::deep_compare: true
+    pacemaker::resource::ip::deep_compare: true
+    pacemaker::resource::ocf::deep_compare: true
+    cinder::config::cinder_config:
+      # [fc-zone-manager]
+      fc-zone-manager/brcd_sb_connector:
+        value: cinder.zonemanager.drivers.brocade.brcd_fc_zone_client_cli.BrcdFCZoneClientCLI
+      fc-zone-manager/fc_fabric_names:
+        value: BRCD_FAB_1,BRCD_FAB_2
+      fc-zone-manager/fc_san_lookup_service:
+        value: cinder.zonemanager.drivers.brocade.brcd_fc_san_lookup_service.BrcdFCSanLookupService
+      fc-zone-manager/zone_driver:
+        value: cinder.zonemanager.drivers.brocade.brcd_fc_zone_driver.BrcdFCZoneDriver
+      # [BRCD_FAB_1]
+      BRCD_FAB_1/fc_fabric_address:
+        value: 10.50.0.33
+      BRCD_FAB_1/fc_fabric_user:
+        value: admin
+      BRCD_FAB_1/fc_fabric_password:
+        value: password
+      BRCD_FAB_1/zoning_policy:
+        value: initiator-target
+      BRCD_FAB_1/zone_activate:
+        value: true
+      BRCD_FAB_1/zone_name_prefix:
+        value: cld13b6
+      # [BRCD_FAB_2]
+      BRCD_FAB_2/fc_fabric_address:
+        value: 10.50.0.36
+      BRCD_FAB_2/fc_fabric_user:
+        value: admin
+      BRCD_FAB_2/fc_fabric_password:
+        value: password
+      BRCD_FAB_2/zoning_policy:
+        value: initiator-target
+      BRCD_FAB_2/zone_activate:
+        value: true
+      BRCD_FAB_2/zone_name_prefix:
+        value: cld13b6
+      # first backend        
+      3parfc_1/hpe3par_api_url:
+        value: https://10.50.3.22:8080/api/v1
+      3parfc_1/hpe3par_username:
+        value: 3paradm
+      3parfc_1/hpe3par_password:
+        value: 3pardata
+      3parfc_1/hpe3par_debug:
+        value: True
+      3parfc_1/san_ip:
+        value: 10.50.3.22
+      3parfc_1/san_login:
+        value: 3paradm
+      3parfc_1/san_password:
+        value: 3pardata
+      3parfc_1/volume_backend_name:
+        value: 3parfc_1
+      3parfc_1/hpe3par_cpg:
+        value: DEFAULT_CPG
+      3parfc_1/volume_driver:
+        value: cinder.volume.drivers.hpe.hpe_3par_fc.HPE3PARFCDriver
+      # second backend        
+      3parfc_2/hpe3par_api_url:
+        value: https://10.50.3.22:8080/api/v1
+      3parfc_2/hpe3par_username:
+        value: 3paradm
+      3parfc_2/hpe3par_password:
+        value: 3pardata
+      3parfc_2/hpe3par_debug:
+        value: True
+      3parfc_2/san_ip:
+        value: 10.50.3.22
+      3parfc_2/san_login:
+        value: 3paradm
+      3parfc_2/san_password:
+        value: 3pardata
+      3parfc_2/volume_backend_name:
+        value: 3parfc_2
+      3parfc_2/hpe3par_cpg:
+        value: GOLD_CPG
+      3parfc_2/volume_driver:
+        value: cinder.volume.drivers.hpe.hpe_3par_fc.HPE3PARFCDriver
+    cinder_user_enabled_backends: ['3parfc_1', '3parfc_2']
+

--- a/custom_hpe_images_iscsi.yaml
+++ b/custom_hpe_images_iscsi.yaml
@@ -1,0 +1,57 @@
+parameter_defaults:
+  DockerCinderVolumeImage: 10.50.9.100:8787/rhosp13/openstack-cinder-volume-hpe:latest
+  CinderEnableIscsiBackend: false
+  Debug: true
+  ControllerExtraConfig:
+    pacemaker::resource::bundle::deep_compare: true
+    pacemaker::resource::ip::deep_compare: true
+    pacemaker::resource::ocf::deep_compare: true
+    cinder::config::cinder_config:
+      # first backend        
+      3pariscsi_1/hpe3par_api_url:
+        value: https://10.50.3.9:8080/api/v1
+      3pariscsi_1/hpe3par_username:
+        value: 3paradm
+      3pariscsi_1/hpe3par_password:
+        value: 3pardata
+      3pariscsi_1/hpe3par_debug:
+        value: True
+      3pariscsi_1/san_ip:
+        value: 10.50.3.9
+      3pariscsi_1/san_login:
+        value: 3paradm
+      3pariscsi_1/san_password:
+        value: 3pardata
+      3pariscsi_1/volume_backend_name:
+        value: 3pariscsi_1
+      3pariscsi_1/hpe3par_cpg:
+        value: tilay_r1
+      3pariscsi_1/hpe3par_iscsi_ips:
+        value: 10.50.3.59, 10.50.3.60
+      3pariscsi_1/volume_driver:
+        value: cinder.volume.drivers.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver
+      # second backend        
+      3pariscsi_2/hpe3par_api_url:
+        value: https://10.50.3.24:8080/api/v1
+      3pariscsi_2/hpe3par_username:
+        value: 3paradm
+      3pariscsi_2/hpe3par_password:
+        value: 3pardata
+      3pariscsi_2/hpe3par_debug:
+        value: True
+      3pariscsi_2/san_ip:
+        value: 10.50.3.24
+      3pariscsi_2/san_login:
+        value: 3paradm
+      3pariscsi_2/san_password:
+        value: 3pardata
+      3pariscsi_2/volume_backend_name:
+        value: 3pariscsi_2
+      3pariscsi_2/hpe3par_cpg:
+        value: FC_r5
+      3pariscsi_2/hpe3par_iscsi_ips:
+        value: 10.50.3.2, 10.50.2.150
+      3pariscsi_2/volume_driver:
+        value: cinder.volume.drivers.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver
+    cinder_user_enabled_backends: ['3pariscsi_1', '3pariscsi_2']
+


### PR DESCRIPTION
For 3par backend, attached two yaml files: one for iscsi and other for FC.
At any time, only one (either iscsi or FC) can be used.
Overcloud needs to be deleted and deployed again.
In overcloud deploy command, add yaml file with “-e” option.
